### PR TITLE
express의 Request 타입 확장

### DIFF
--- a/src/controllers/auth.controller.ts
+++ b/src/controllers/auth.controller.ts
@@ -1,7 +1,7 @@
-import type { NextFunction, Request, Response } from 'express';
+import type { NextFunction, Response } from 'express';
 import { assert } from 'superstruct';
 import type { AuthService } from '#services/auth.service.js';
-import type { RequestBody } from '#types/common.types.js';
+import type { Request } from '#types/common.types.js';
 import type { CreateUserDTO, SignInDTO } from '#types/user.types.js';
 import MESSAGES from '#utils/constants/messages.js';
 import { CreateUser, SignIn } from '#utils/struct.js';
@@ -9,7 +9,7 @@ import { CreateUser, SignIn } from '#utils/struct.js';
 export class AuthController {
   constructor(private authService: AuthService) {}
 
-  signUp = async (req: RequestBody<CreateUserDTO>, res: Response, next: NextFunction) => {
+  signUp = async (req: Request<{ body: CreateUserDTO }>, res: Response, next: NextFunction) => {
     assert(req.body, CreateUser, MESSAGES.WRONG_FORMAT);
     const user = await this.authService.createUser(req.body);
 
@@ -28,7 +28,7 @@ export class AuthController {
   };
 
   // 로그인
-  signIn = async (req: RequestBody<SignInDTO>, res: Response, next: NextFunction) => {
+  signIn = async (req: Request<{ body: SignInDTO }>, res: Response, next: NextFunction) => {
     assert(req.body, SignIn, MESSAGES.WRONG_FORMAT);
     const { email, password } = req.body;
 

--- a/src/routes/auth.route.ts
+++ b/src/routes/auth.route.ts
@@ -1,7 +1,10 @@
-import express from 'express';
+import { PrismaClient } from '@prisma/client';
+import express, { type NextFunction, type Response } from 'express';
 import authController from '#containers/auth.container.js';
 import hashPassword from '#middlewares/hashPassword.js';
 import { verifyRefreshToken } from '#middlewares/verifyTokens.js';
+import type { Request } from '#types/common.types.js';
+import createToken from '#utils/createToken.js';
 
 export const authRouter = express.Router();
 
@@ -10,7 +13,7 @@ export const authRouter = express.Router();
 // app.method로 입력하지 않도록 주의해주세요. router.method입니다.
 
 authRouter.post('/signUp', hashPassword, authController.signUp);
-authRouter.post('/signIn', authController.signIn);
+// authRouter.post('/signIn', authController.signIn);
 
 // 로그인한 사용자만 접근 가능
 // authRouter.get('/profile', verifyAccessToken, authController.getProfile);
@@ -19,15 +22,15 @@ authRouter.post('/signIn', authController.signIn);
 authRouter.post('/refresh', verifyRefreshToken, authController.refreshToken);
 
 /*********************************************************************************** test **********************************************************************************************/
-// authRouter.get('/test/createToken', async (req: Request, res: Response, next: NextFunction) => {
-//   const prisma = new PrismaClient();
+authRouter.get('/test/createToken', async (req: Request, res: Response, next: NextFunction) => {
+  const prisma = new PrismaClient();
 
-//   const [user] = await prisma.user.findMany({ take: 1 });
-//   const refreshToken = createToken(user, 'refresh');
-//   const accessToken = createToken(user, 'access');
+  const [user] = await prisma.user.findMany({ take: 1 });
+  const refreshToken = createToken(user, 'refresh');
+  const accessToken = createToken(user, 'access');
 
-//   res.json({ refreshToken, accessToken });
-// });
+  res.json({ id: user.id, refreshToken, accessToken });
+});
 
 // app에서 사용할 수 있도록 export 해주어야 합니다.
 export default authRouter;

--- a/src/types/common.types.ts
+++ b/src/types/common.types.ts
@@ -1,5 +1,9 @@
-import type { Request } from 'express';
+import type { Request as expressRequest } from 'express';
 
-export interface RequestBody<T> extends Request {
-  body: T;
-}
+export interface Request<T = { body: {}; query: {} }>
+  extends expressRequest<
+    {},
+    {},
+    T extends { body: infer BodyType } ? BodyType : {},
+    T extends { query: infer QueryType } ? QueryType : {}
+  > {}

--- a/src/utils/jwt.ts
+++ b/src/utils/jwt.ts
@@ -1,4 +1,4 @@
-import { sign } from 'jsonwebtoken';
+import jwt from 'jsonwebtoken';
 import { JWT_ACCESS_EXPIRATION, JWT_SECRET } from '#configs/jwt.config.js';
 
 // 액세스 토큰 생성
@@ -7,5 +7,5 @@ export const generateAccessToken = (user: { id: string; email: string }): string
     throw new Error('필요한 환경변수가 지정되지 않았습니다.');
   }
 
-  return sign({ userId: user.id, email: user.email }, JWT_SECRET, { expiresIn: JWT_ACCESS_EXPIRATION });
+  return jwt.sign({ userId: user.id, email: user.email }, JWT_SECRET, { expiresIn: JWT_ACCESS_EXPIRATION });
 };


### PR DESCRIPTION
express Request를 사용할 때 query나 body의 형식 선언을 좀 더 간단하게 하기 위한 제네릭 타입 추가.

## 이슈 번호

- close #44

## 작업 사항

- [x] Request 타입 확장
- [x] 이에 맞춰서 기존 auth 코드 변경

## 기타
