### PR TITLE
🐛 Fix #209 거절,취소 사유 목데이터 추가

### DIFF
--- a/prisma/mock/abortReasonMock.ts
+++ b/prisma/mock/abortReasonMock.ts
@@ -1,0 +1,22 @@
+export const ABORT_REASONS = [
+  {
+    content: '거절,취소 사유',
+    adminId: '590602e9-3796-4287-bca1-de9969139fbc',
+    challengeId: 'd0611542-61b2-4ff1-8e3d-745413cdfce5',
+  },
+  {
+    content: '거절,취소 사유',
+    adminId: '590602e9-3796-4287-bca1-de9969139fbc',
+    challengeId: '3508f13c-7399-48d1-b35a-a9e5e2ed4b06',
+  },
+  {
+    content: '거절,취소 사유',
+    adminId: '590602e9-3796-4287-bca1-de9969139fbc',
+    challengeId: 'c756848e-8940-41bd-959f-68e0f34563fc',
+  },
+  {
+    content: '거절,취소 사유',
+    adminId: '590602e9-3796-4287-bca1-de9969139fbc',
+    challengeId: 'fc299a7d-9b3f-4ac6-afa5-17d035bc3388',
+  },
+];

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,6 +1,7 @@
 import { PrismaClient } from '@prisma/client';
 import FEEDBACKS from '@/prisma/mock/feedbackMock.js';
 import RECIPES from '@/prisma/mock/recipeMock.js';
+import { ABORT_REASONS } from './mock/abortReasonMock.js';
 import { CHALLENGES } from './mock/challengeMock.js';
 import { CHALLENGE_WORKS, WORK_IMAGES } from './mock/challengeWorkMock.js';
 import USERS from './mock/userMock.js';
@@ -8,6 +9,7 @@ import USERS from './mock/userMock.js';
 const prisma = new PrismaClient();
 
 async function main() {
+  await prisma.abortReason.deleteMany();
   await prisma.recipe.deleteMany();
   await prisma.feedback.deleteMany();
   await prisma.workImage.deleteMany();
@@ -54,6 +56,10 @@ async function main() {
 
   await prisma.recipe.createMany({
     data: RECIPES,
+    skipDuplicates: true,
+  });
+  await prisma.abortReason.createMany({
+    data: ABORT_REASONS,
     skipDuplicates: true,
   });
 }


### PR DESCRIPTION
목데이터안의 거절, 취소 상태의 챌린지가 있지만 그에 해당하는 거절,취소 사유 목데이터가 없으므로 추가

## 이슈 번호

- close #209 

## 작업 사항 설명
목데이터에 있는 취소,거부된 챌린지가 있지만 그에 해당하는 거부사유 목데이터가 없으므로 추가
## 작업 사항

- [x] 목데이터에 거부나 취소된 챌린지의 거부사유 목데이터 추가

## 기타
